### PR TITLE
Quick and dirty verbosity control for cron run scripts

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9,6 +9,8 @@ def init_argparser():
     parser = argparse.ArgumentParser(description='Elisa viihde library scripts.')
     parser.add_argument('-u', '--user', help='username')
     parser.add_argument('-p', '--passfile', help='password file')
+    parser.add_argument('-v', '--verbose', action='count', help='script verbosity. -v default, -vvv very', default=0)
+
     return parser
 
 

--- a/cron_dups.py
+++ b/cron_dups.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# example: python cron_dups.py -u <username> -p passwd -v
+
+import cli
+import elisaviihde
+
+def main():
+    parser = cli.init_argparser()
+    params = parser.parse_args()
+
+    username = cli.read_input(params.user, 'Elisa Viihde Username')
+    password = cli.read_password(params.passfile, 'Elisa Viihde Password')
+
+    e = elisaviihde.Elisaviihde(params.verbose)
+
+    if not e.login(username, password):
+        exit(-1)
+
+    # From root up
+    folder = e.find_folder_by_id(0)
+
+    recordings = e.ls_recordings_recursive(folder, [])
+    found_duplicates = find_duplicates(recordings, params.verbose)
+
+    # If nothing to delete, end
+    if len(found_duplicates) < 1:
+        return
+
+    # Loop-de-loop
+    for key, recordings in found_duplicates.iteritems():
+        if params.verbose > 0:
+            print 'Processing:', key[0], ';', key[1]
+        first = True
+        for recording in recordings:
+            if first:
+                if params.verbose > 1:
+                    print 'Kept first', recording['startTime'], recording['channel']
+                first = False
+            else:
+                status = e.delete(recording['programId'])
+                if params.verbose > 2:
+                    print 'DELETED', status, recording['startTime'], recording['channel']
+    if params.verbose > 0:
+        print 'Delete duplicates done.'
+        
+    
+def find_duplicates(recordings, verbosity):
+    # arrange programs as hastable {(name, description): [recording, recording], ...}
+    recordings_dict = {}
+    for recording in recordings:
+        key = (recording['name'].strip(), recording.get('description', '').strip())
+        value = recordings_dict.get(key, [])
+        value.append(recording)
+        recordings_dict[key] = value
+    
+    # hastable {(name, description): [recording, recording], ...}
+    # where recordings ordered by not-HD, startTimeUTC timestamp
+    duplicate_recordings_dict = {}
+    for key, recordings in recordings_dict.iteritems():
+        if len(recordings) > 1:
+            recordings.sort(key=lambda r: (not r['channel'].endswith('HD'), r['startTimeUTC']))
+            duplicate_recordings_dict[key] = recordings
+            if verbosity > 1:
+                print 'Found duplicates for:', key[0]
+            for recording in recordings:
+                if verbosity > 2:
+                    print '*', recording['startTime'], recording['channel']
+    if verbosity > 0:
+        print 'Total', len(duplicate_recordings_dict)
+    return duplicate_recordings_dict
+
+if __name__ == '__main__':
+    main()

--- a/elisaviihde.py
+++ b/elisaviihde.py
@@ -6,14 +6,18 @@ class Elisaviihde:
     url = 'https://elisaviihde.fi/'
 
     # please call login after init
-    def __init__(self):
+    def __init__(self, verbosity=4):
         self.session = requests.Session()
+        self.verbosity = verbosity
 
     def login(self, username, password):
         params = {'username': username, 'password': password}
         r = self.session.post(Elisaviihde.url + 'api/user', data=params)
         login_ok = r.status_code == 200
-        print 'Elisa Viihde Login', 'OK' if login_ok else 'FAILED'
+        if self.verbosity > 1: # If verbosity is >1 we tell about login success and failure
+            print 'Elisa Viihde Login', 'OK' if login_ok else 'FAILED'
+        if self.verbosity == 1 and not login_ok: # We notify about login failures only with -v 
+            print 'Elisa Viihde Login Failed'
         return login_ok
 
     ''' (folders contains folders recursively)
@@ -67,13 +71,15 @@ thumbnailUrl: "//thumbs.elisaviihde.fi/thumbnails/1902642.jpg"
                 break
             allresults.extend(result)
             page += 1
-        print 'Found', len(allresults), 'recordings for folder', folderid
+        if self.verbosity > 2:
+            print 'Found', len(allresults), 'recordings for folder', folderid
         return allresults
 
     def delete(self, programid):
         r = self.session.delete(Elisaviihde.url + 'tallenteet/api/recordings/' + str(programid))
         result = r.status_code == 200
-        print 'Deleted recording', programid, ':', result
+        if self.verbosity > 1:
+            print 'Deleted recording', programid, ':', result
         return result
 
     def create_subfolder(self, foldername, parentid):
@@ -81,14 +87,16 @@ thumbnailUrl: "//thumbs.elisaviihde.fi/thumbnails/1902642.jpg"
         data = {'parentId': parentid, 'folderName': foldername}
         r = self.session.put(Elisaviihde.url + 'tallenteet/api/folder', headers=headers, data=json.dumps(data))
         newfolderid = int(r.text)
-        print 'Created folder', foldername, ':', newfolderid
+        if self.verbosity > 2:
+            print 'Created folder', foldername, ':', newfolderid
         return self.find_folder_by_id(newfolderid)
 
     def move(self, programid, folderid):
         params = {'folderId': folderid}
         r = self.session.put(Elisaviihde.url + 'tallenteet/api/recordings/move/' + str(programid), params=params)
         result = r.status_code == 200
-        print 'Moved recording', programid, 'to folderid', folderid, ':', result
+        if self.verbosity > 1:
+            print 'Moved recording', programid, 'to folderid', folderid, ':', result
         return result
 
     def find_folder_by_name(self, foldername):


### PR DESCRIPTION
Currently defaults to zero (1 could be more useful), didn't know how to keep old behaviour regarding verbosity.

`cron_dups.py` has been added as base implementation example.
